### PR TITLE
[phonesim] Correct systemd unit path for 64-bit. Contributes to JB#52788

### DIFF
--- a/rpm/phonesim.desktop
+++ b/rpm/phonesim.desktop
@@ -2,8 +2,10 @@
 Type=Application
 Name=Phonesim
 Categories=Applications;
-Exec=/bin/systemctl --user start phonesim.service
+Exec=/usr/bin/systemctl --user start phonesim.service
 Icon=icon-launcher-default
 
 X-Desktop-File-Install-Version=0.20
 
+[X-Sailjail]
+Sandboxing=Disabled

--- a/rpm/phonesim.spec
+++ b/rpm/phonesim.spec
@@ -51,8 +51,8 @@ mkdir -p %{buildroot}%{_datadir}/phonesim/
 cp -a %{SOURCE3} %{buildroot}%{_datadir}/phonesim/
 mkdir -p %{buildroot}%{_userunitdir}
 cp -a %{SOURCE4} %{buildroot}%{_userunitdir}
-mkdir -p %{buildroot}%{_sysconfdir}/dbus-1/system.d/
-cp -a %{SOURCE5} %{buildroot}%{_sysconfdir}/dbus-1/system.d/
+mkdir -p %{buildroot}%{_datadir}/dbus-1/system.d/
+cp -a %{SOURCE5} %{buildroot}%{_datadir}/dbus-1/system.d/
 mkdir -p %{buildroot}%{_datadir}/phonesim/
 cp -a %{SOURCE6} %{buildroot}%{_datadir}/phonesim/
 
@@ -75,4 +75,4 @@ desktop-file-install --delete-original       \
 %{_datadir}/phonesim/nemomobile.xml
 %{_sysconfdir}/ofono/phonesim.conf
 %{_userunitdir}/phonesim.service
-%{_sysconfdir}/dbus-1/system.d/ofono-phonesim.conf
+%{_datadir}/dbus-1/system.d/ofono-phonesim.conf

--- a/rpm/phonesim.spec
+++ b/rpm/phonesim.spec
@@ -18,6 +18,7 @@ BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Script)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Widgets)
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  desktop-file-utils
 
 %description
@@ -48,8 +49,8 @@ mkdir -p %{buildroot}%{_datadir}/applications/
 cp -a %{SOURCE2} %{buildroot}%{_datadir}/applications/
 mkdir -p %{buildroot}%{_datadir}/phonesim/
 cp -a %{SOURCE3} %{buildroot}%{_datadir}/phonesim/
-mkdir -p %{buildroot}%{_libdir}/systemd/user/
-cp -a %{SOURCE4} %{buildroot}%{_libdir}/systemd/user/
+mkdir -p %{buildroot}%{_userunitdir}
+cp -a %{SOURCE4} %{buildroot}%{_userunitdir}
 mkdir -p %{buildroot}%{_sysconfdir}/dbus-1/system.d/
 cp -a %{SOURCE5} %{buildroot}%{_sysconfdir}/dbus-1/system.d/
 mkdir -p %{buildroot}%{_datadir}/phonesim/
@@ -73,5 +74,5 @@ desktop-file-install --delete-original       \
 %defattr(-,root,root,-)
 %{_datadir}/phonesim/nemomobile.xml
 %{_sysconfdir}/ofono/phonesim.conf
-%{_libdir}/systemd/user/phonesim.service
+%{_userunitdir}/phonesim.service
 %{_sysconfdir}/dbus-1/system.d/ofono-phonesim.conf


### PR DESCRIPTION
Use correct path for systemd unit. They are located in /usr/lib/systemd
regardless of device bitness.