### PR TITLE
[phonesim] Fix powering on. Contributes to JB#52788

### DIFF
--- a/rpm/exec_phonesim
+++ b/rpm/exec_phonesim
@@ -1,14 +1,20 @@
-#!/bin/bash
-if [ "$1" == "1" ]; then
+#!/bin/sh
+set_phonesim_property() {
+    /usr/sbin/run-blts-root /usr/bin/dbus-send --system --print-reply \
+        --type=method_call --dest=org.ofono /phonesim org.ofono.Modem.SetProperty \
+        string:"$1" variant:boolean:"$2" > /dev/null || exit 1
+}
+
+if [ "$1" = "1" ]; then
     echo "Enabling the phonesim modem"
     /bin/sleep 2
-    /usr/bin/dbus-send --system --type=method_call --dest=org.ofono /phonesim org.ofono.Modem.SetProperty string:"Powered" variant:boolean:true
-    /usr/bin/dbus-send --system --type=method_call --dest=org.ofono /phonesim org.ofono.Modem.SetProperty string:"Online" variant:boolean:true
+    set_phonesim_property Powered true
+    set_phonesim_property Online true
 fi
 
-if [ "$1" == "0" ]; then
+if [ "$1" = "0" ]; then
     echo "Disabling the phonesim modem"
-    /usr/bin/dbus-send --system --type=method_call --dest=org.ofono /phonesim org.ofono.Modem.SetProperty string:"Online" variant:boolean:false
-    /usr/bin/dbus-send --system --type=method_call --dest=org.ofono /phonesim org.ofono.Modem.SetProperty string:"Powered" variant:boolean:false
+    set_phonesim_property Online false
+    set_phonesim_property Powered false
 fi
 

--- a/rpm/phonesim.spec
+++ b/rpm/phonesim.spec
@@ -12,6 +12,7 @@ Source4:    phonesim.service
 Source5:    ofono-phonesim.conf
 Source6:    exec_phonesim
 Requires:   %{name}-configs
+Requires:   blts-tools
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Xml)
 BuildRequires:  pkgconfig(Qt5Network)
@@ -64,6 +65,7 @@ desktop-file-install --delete-original       \
 
 %files
 %defattr(-,root,root,-)
+%license COPYING
 %{_bindir}/phonesim
 %dir %{_datadir}/phonesim
 %{_datadir}/phonesim/default.xml


### PR DESCRIPTION
Powering on /phonesim modem must be done as privileged enough user. It
also requires dbus-send to live long enough to check for its
permissions, thus use --print-reply. Also made this POSIX compatible as
there is no reason to use bashisms here.

Require blts-tools to have run-blts-root available.

Also add missing license file.