### PR TITLE
Fix incomingConnection override on 64-bit and some packaging fixes

### DIFF
--- a/phonesim.pro
+++ b/phonesim.pro
@@ -9,8 +9,8 @@ QT = core gui xml network script dbus widgets
 target.path = /usr/bin
 INSTALLS += target
 
-xml.files = src/default.xml
-xml.path = /usr/share/phonesim/default.xml
+xml.files = src/default.xml src/GSMSpecification.xml
+xml.path = /usr/share/phonesim
 INSTALLS += xml
 
 HEADERS = \

--- a/rpm/phonesim.spec
+++ b/rpm/phonesim.spec
@@ -63,12 +63,20 @@ desktop-file-install --delete-original       \
   --dir %{buildroot}%{_datadir}/applications             \
    %{buildroot}%{_datadir}/applications/*.desktop
 
+# Remove a mistakenly created directory
+%pre
+if [ "$1" -eq 2 ]
+then
+    rm -rf %{_datadir}/phonesim/default.xml
+fi
+
 %files
 %defattr(-,root,root,-)
 %license COPYING
 %{_bindir}/phonesim
 %dir %{_datadir}/phonesim
 %{_datadir}/phonesim/default.xml
+%{_datadir}/phonesim/GSMSpecification.xml
 %{_datadir}/phonesim/exec_phonesim
 %{_datadir}/applications/phonesim.desktop
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -44,7 +44,7 @@ void PhoneSimServer::setHardwareManipulator(HardwareManipulatorFactory *f)
         f->setRuleFile(filename);
 }
 
-void PhoneSimServer::incomingConnection(int s)
+void PhoneSimServer::incomingConnection(qintptr s)
 {
   SimRules *sr = new SimRules(s, this, filename, fact);
     sr->setPhoneNumber(QString::number(phonenumber));

--- a/src/server.h
+++ b/src/server.h
@@ -40,7 +40,7 @@ public:
     SimRules *rules() const { return currentRules; }
 
 protected:
-    void incomingConnection(int s);
+    void incomingConnection(qintptr s) override;
 
 private:
     QString filename;


### PR DESCRIPTION
Fix QTcpserver::incomingConnection override on 64-bit. The signature was wrong and there was no override keyword so this was left undetected.

Add GSMSpecification.xml back. GSMSpecification.xml was left out when build system was converted from autotools to qmake. Add it back.

Fix packaging mistake with default.xml. It was installed inside extra directory. To avoid issues with upgrading there is a %pre scriptlet that removes that directory before installing, otherwise rpm can't replace it with a file.